### PR TITLE
Get encoders to properly serialize nested fields

### DIFF
--- a/src/schemas/common_types.py
+++ b/src/schemas/common_types.py
@@ -32,17 +32,12 @@ class Time(pydantic.BaseModel):
     # TODO: Add this field back in
     # hours: Optional[List[int]]
 
-    # TODO: Figure out why this didn't work and fix it.
     def serialize(self):
         payload: Dict[str, Any] = {"type": self.type}
         if self.type == "every_hour":
             payload["interval"] = self.interval
-        # else:
-        #     payload['hours'] = self.hours
-
-        print("Doing the thing")
-        print(payload)
-
+        elif self.type == "at_exact_hours":
+            payload['hours'] = self.hours
         return payload
 
 

--- a/src/schemas/job.py
+++ b/src/schemas/job.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Any
 
 import pydantic
 
-from .common_types import Execution, Settings, Schedule, Triggers
+from .common_types import Execution, Settings, Schedule, Time, Triggers
 from .custom_environment_variable import CustomEnvironmentVariable
 
 
@@ -56,6 +56,9 @@ class JobDefinition(pydantic.BaseModel):
             data["custom_environment_variables"] = []
 
         super().__init__(**data)
+
+    class Config:
+        json_encoders = {Time: lambda t: t.serialize()}
 
     def to_payload(self):
         """Create a dbt Cloud API payload for a JobDefinition."""


### PR DESCRIPTION
This seems to be a limitation of pydantic: it doesn't pull in configs (including encoder functions) for nested classes, so any custom encoding must be on the top-level object being serialized.

The ideal solution here might be having a `serialize` method on any model which:
- needs custom serialization, or
- contains a model which does
though at that point it sounds like we may also want a base class which handles custom serialization by default...and at that point it seems like we should just submit a patch to Pydantic?

Open to feedback about how to do this cleanly.