### PR TITLE
Add click implementation for proper cli support

### DIFF
--- a/src/loader/load.py
+++ b/src/loader/load.py
@@ -5,10 +5,9 @@ import yaml
 from schemas.job import JobDefinition
 
 
-def load_job_definitions(path) -> Dict[str, JobDefinition]:
+def load_job_definitions(config_file) -> Dict[str, JobDefinition]:
     """Load a job YAML file into a dictionary of JobDefinitions"""
-    with open(path, "r") as config_file:
-        config = yaml.safe_load(config_file)
+    config = yaml.safe_load(config_file)
 
     return {
         identifier: JobDefinition(**job, identifier=identifier)


### PR DESCRIPTION
Resolves #9 

This pull request implements a _basic_ click-based CLI for the `main.py` command, allowing users to supply a POSIX-compliant path to the `jobs.yml` file. This file is opened and passed to the loader function automagially. Along the way, I also implemented basic usage for this command.