### PR TITLE
Feature: Implement CustomEnvironmentVariable creation via API, and fix some type hinting

### DIFF
--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -30,10 +30,8 @@ class DBTCloud:
 
     def _clear_env_var_cache(self, job_definition_id: int) -> None:
         """Clear out any cached environment variables for a given job."""
-        if job_definition_id not in self._environment_variable_cache:
-            return
-
-        del self._environment_variable_cache[job_definition_id]
+        if job_definition_id in self._environment_variable_cache:
+            del self._environment_variable_cache[job_definition_id]
 
     def _check_for_creds(self):
         """Confirm the presence of credentials"""

--- a/src/main.py
+++ b/src/main.py
@@ -22,7 +22,7 @@ def cli(config):
     dbt_cloud = DBTCloud(
         account_id=list(defined_jobs.values())[0].account_id,
         api_key=os.environ.get("API_KEY"),
-        base_url=os.environ.get("DBT_BASE_URL", "https://cloud.getdbt.com")
+        base_url=os.environ.get("DBT_BASE_URL", "https://cloud.getdbt.com"),
     )
     cloud_jobs = dbt_cloud.get_jobs()
     tracked_jobs = {
@@ -64,24 +64,35 @@ def cli(config):
         job_id = mapping_job_identifier_job_id[job.identifier]
         for env_var_yml in job.custom_environment_variables:
             env_var_yml.job_definition_id = job_id
-            updated_env_vars = dbt_cloud.update_env_var(project_id=job.project_id, job_id=job_id, custom_env_var=env_var_yml)
+            updated_env_vars = dbt_cloud.update_env_var(
+                project_id=job.project_id, job_id=job_id, custom_env_var=env_var_yml
+            )
 
     # Delete the env vars from dbt Cloud that are not in the yml
     for job in defined_jobs.values():
         job_id = mapping_job_identifier_job_id[job.identifier]
 
         # We get the env vars from dbt Cloud, now that the YML ones have been replicated
-        env_var_dbt_cloud = dbt_cloud.get_env_vars(project_id=job.project_id, job_id=job_id)
+        env_var_dbt_cloud = dbt_cloud.get_env_vars(
+            project_id=job.project_id, job_id=job_id
+        )
 
         # And we get the list of env vars defined for a given job in the YML
-        env_vars_for_job = [env_var.name for env_var in job.custom_environment_variables]
+        env_vars_for_job = [
+            env_var.name for env_var in job.custom_environment_variables
+        ]
 
         for env_var, env_var_val in env_var_dbt_cloud.items():
             # If the env var is not in the YML but is defined at the "job" level in dbt Cloud, we delete it
-            if env_var not in env_vars_for_job and "job" in env_var_val :
+            if env_var not in env_vars_for_job and "job" in env_var_val:
                 logger.info(f"{env_var} not in the YML file but in the dbt Cloud job")
-                dbt_cloud.delete_env_var(project_id=job.project_id, env_var_id=env_var_val["job"]["id"])
-                logger.info(f"Deleted the env_var {env_var} for the job {job.identifier}")
+                dbt_cloud.delete_env_var(
+                    project_id=job.project_id, env_var_id=env_var_val["job"]["id"]
+                )
+                logger.info(
+                    f"Deleted the env_var {env_var} for the job {job.identifier}"
+                )
+
 
 if __name__ == "__main__":
     cli()

--- a/src/schemas/custom_environment_variable.py
+++ b/src/schemas/custom_environment_variable.py
@@ -21,14 +21,15 @@ class CustomEnvironmentVariable(pydantic.BaseModel):
 
 class CustomEnvironmentVariablePayload(CustomEnvironmentVariable):
     """A dbt Cloud-serializable representation of a CustomEnvironmentVariables."""
+
     id: Optional[int]
     project_id: int
     account_id: int
     raw_value: str
 
     def __init__(self, **data: Any):
-        data['raw_value'] = data['value']
+        data["raw_value"] = data["value"]
         super().__init__(**data)
 
     class Config:
-        fields = {'value': {'exclude': True}}
+        fields = {"value": {"exclude": True}}


### PR DESCRIPTION
Resolves #18

This PR implements the `CustomEnvironmentVariable` creation flow, as well has resolves some type hinting defects outlines in #18. To accomplish this, I've done a handful of things:
1. Created a `CustomEnvironmentVariablePayload` class, which extends the `CustomEnvironmentVariable` class. This class has additional information required by the API for creating/interacting with `CustomEnvironmentVariables` within dbt Cloud.
2. Implemented a `create_env_var` method in `DbtCloud`, which handles the API calls for creating an environment variable. ~Previously, the creation of new variables resulted in an exception being thrown.~ Exceptions are still thrown when a new environment variable needs to be created.
3. Simplification of logic. Once we started encapsulating data in objects and wrapping work in methods, a few opportunities for logic simplification came up. This means that it's a little bit easier to follow what the `update_env_var` method is up to.