### PR TITLE
Create issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug] Issue Title"
+labels: bug, triage
+assignees: b-per, nicholasyager
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS [e.g. iOS]:
+ - dbt Core Version [e.g. 1.3.1]:
+ - `dbt-jobs-as-code` Version [e.g. 1.0.0]:
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature] Title"
+labels: enhancement, triage
+assignees: b-per, nicholasyager
+
+---
+
+**Describe the feature**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Who will this benefit?**
+What kind of use case will this feature be useful for? Please be specific and provide examples, this will help us prioritize properly.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+**Are you interested in contributing this feature?**
+Let us know if you want to write some code, and how we can help!


### PR DESCRIPTION
This pull requests implements straightforward feature request and bug report Github issue templates. This currently leverages standard issue template markdown files. Once this repo is public, we can investigate the use of [Issue Forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms), which look wildly useful.

Resolves #43 