### PR TITLE
Adding dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly
+    - package-ecosystem: pip
+      directory: /
+      schedule:
+          interval: weekly


### PR DESCRIPTION
There are outdated GitHub actions and python packages in this repo. This PR adds dependabot for these so that PRs are automatically created to keep these versions up to date and secure.