### PR TITLE
Support PR forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Run pytest on PRs
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - '**'
   schedule:


### PR DESCRIPTION
The CI for my PR [here](https://github.com/dbt-labs/dbt-jobs-as-code/pull/95) is failing because it cannot access secrets that are required for environment variables. This PR moves the trigger from `pull_request` to `pull_request_target` so that CI runs can access secrets, but still use the workflow definition from the target branch.