### PR TITLE
Bump `setup-python` action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
All CI runs result in the below warnings being raised ([source](https://github.com/dbt-labs/dbt-jobs-as-code/actions/runs/11088933054)):
![image](https://github.com/user-attachments/assets/5e824706-b360-4361-83c3-c88d239e5669)

This PR bumps the `setup-python` action to the latest major version.