### PR TITLE
Correcting entrypoint path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ pytest = "^7.2.0"
 jsonschema = "^4.17.3"
 
 [tool.poetry.scripts]
-dbt-jobs-as-code = "src.main:cli"
+dbt-jobs-as-code = "dbt_jobs_as_code.main:cli"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
In #95 we moved to a proper directory structure for python packages. I forgot to update the entrypoint accordingly. Note that this should be included in the 0.9 release. (This also raises some questions regarding the test coverage of this repo, but that's a topic for another day)