### PR TITLE
Moving deps to dev only

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1148,4 +1148,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "9a66e20621beb916b27605f18839fb4dc4524506149c7a2248aaa9af7b8d296a"
+content-hash = "cf3dbff065c7999e4642a976097d2c893a81cc19d20b793816fb927d34b58361"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,15 +22,15 @@ rich = "^12.6.0"
 PyYAML = "^6.0.1"
 python-dateutil = "^2.9"
 beartype = "^0.18.5"
-pytest-beartype = "^0.0.2"
 jinja2 = "^3.1.4"
 importlib-metadata = ">=6.0,<7"
-coverage = "^7.6.3"
-pytest-cov = "^5.0.0"
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.2.0"
+coverage = "^7.6.3"
 jsonschema = "^4.17.3"
+pytest = "^7.2.0"
+pytest-beartype = "^0.0.2"
+pytest-cov = "^5.0.0"
 
 [tool.poetry.scripts]
 dbt-jobs-as-code = "dbt_jobs_as_code.main:cli"


### PR DESCRIPTION
Some of the recent additional packages in this repo have been added as core dependencies when they are just needed for testing, i.e. they are development dependencies. This PR corrects these packages and updates `poetry.lock` accordingly.