### PR TITLE
Add ability to read from multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The CLI comes with a few different commands
 
 #### `validate`
 
-Command: `dbt-jobs-as-code validate <config_file.yml>`
+Command: `dbt-jobs-as-code validate <config_file_or_pattern.yml>`
 
 Validates that the YAML file has the correct structure
 
@@ -58,13 +58,13 @@ Validates that the YAML file has the correct structure
 
 #### `plan`
 
-Command: `dbt-jobs-as-code plan <config_file.yml>`
+Command: `dbt-jobs-as-code plan <config_file_or_pattern.yml>`
 
 Returns the list of actions create/update/delete that are required to have dbt Cloud reflecting the configuration file
 
 - this command doesn't modify the dbt Cloud jobs
 - this command can be restricted to specific projects and environments
-  - it accepts a list of project IDs or environments IDs to limit the command for: `dbt-jobs-as-code plan <config_file.yml> -p 1234 -p 2345 -e 4567 -e 5678`
+  - it accepts a list of project IDs or environments IDs to limit the command for: `dbt-jobs-as-code plan <config_file_or_pattern.yml> -p 1234 -p 2345 -e 4567 -e 5678`
     - it is possible to limit for specific projects and/or specific environments
     - when both projects and environments are provided, the command will run for the jobs that are both part of the environment ID(s) and the project ID(s) provided
   - or it accepts the flag `--limit-projects-envs-to-yml` to only check jobs that are in the projects and environments listed in the jobs YAML file
@@ -72,13 +72,13 @@ Returns the list of actions create/update/delete that are required to have dbt C
 
 #### `sync`
 
-Command: `dbt-jobs-as-code sync <config_file.yml>`
+Command: `dbt-jobs-as-code sync <config_file_or_pattern.yml>`
 
 Create/update/delete jobs and env vars overwrites in jobs to align dbt Cloud with the configuration file
 
 - ⚠️ this command will modify your dbt Cloud jobs if the current configuration is different from the YAML file
 - this command can be restricted to specific projects and environments
-  - it accepts a list of project IDs or environments IDs to limit the command for: `dbt-jobs-as-code sync <config_file.yml> -p 1234 -p 2345 -e 4567 -e 5678`
+  - it accepts a list of project IDs or environments IDs to limit the command for: `dbt-jobs-as-code sync <config_file_or_pattern.yml> -p 1234 -p 2345 -e 4567 -e 5678`
     - it is possible to limit for specific projects and/or specific environments
   environment ID(s) and the project ID(s) provided
   - or it accepts the flag `--limit-projects-envs-to-yml` to only check jobs that are in the projects and environments listed in the jobs YAML file
@@ -86,12 +86,12 @@ Create/update/delete jobs and env vars overwrites in jobs to align dbt Cloud wit
 
 #### `import-jobs`
 
-Command: `dbt-jobs-as-code import-jobs --config <config_file.yml>` or `dbt-jobs-as-code import-jobs --account-id <account-id>`
+Command: `dbt-jobs-as-code import-jobs --config <config_file_or_pattern.yml>` or `dbt-jobs-as-code import-jobs --account-id <account-id>`
 
 Queries dbt Cloud and provide the YAML definition for those jobs. It includes the env var overwrite at the job level if some have been defined
 
 - it is possible to restrict the list of dbt Cloud Job IDs by adding `... -j 101 -j 123 -j 234`
-- this command also accepts a list of project IDs or environments IDs to limit the command for: `dbt-jobs-as-code sync <config_file.yml> -p 1234 -p 2345 -e 4567 -e 5678`
+- this command also accepts a list of project IDs or environments IDs to limit the command for: `dbt-jobs-as-code sync <config_file_or_pattern.yml> -p 1234 -p 2345 -e 4567 -e 5678`
 - this command accepts a `--include-linked-id` parameter to allow linking the jobs in the YAML to existing jobs in dbt Cloud, by renaming those
 - once the YAML has been retrieved, it is possible to copy/paste it in a local YAML file to create/update the local jobs definition.
 
@@ -99,7 +99,7 @@ Once the configuration is imported, it is possible to "link" existing jobs by us
 
 #### `link`
 
-Command: `dbt-jobs-as-code link <config_file.yml>`
+Command: `dbt-jobs-as-code link <config_file_or_pattern.yml>`
 
 Links dbt Cloud jobs with the corresponding identifier from the YAML file by renaming the jobs, adding the `[[ ... ]]` part in the job name.
 
@@ -110,7 +110,7 @@ Accepts a `--dry-run` flag to see what jobs would be changed, without actually c
 
 #### `unlink`
 
-Command: `dbt-jobs-as-code unlink --config <config_file.yml>` or `dbt-jobs-as-code unlink --account-id <account-id>`
+Command: `dbt-jobs-as-code unlink --config <config_file_or_pattern.yml>` or `dbt-jobs-as-code unlink --account-id <account-id>`
 
 Unlinking jobs removes the `[[ ... ]]` part of the job name in dbt Cloud.
 

--- a/example_cicd/prod_plan_on_pr.yml
+++ b/example_cicd/prod_plan_on_pr.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Run dbt-jobs-as-code
         run: dbt-jobs-as-code plan jobs/jobs.yml --vars-yml jobs/vars_prod.yml --limit-projects-envs-to-yml
+        # or using a file pattern
+        # run: dbt-jobs-as-code plan jobs/**.yml --vars-yml jobs/*_prod.yml --limit-projects-envs-to-yml
         env: 
           DBT_API_KEY: "${{secrets.DBT_API_KEY}}"
           # DBT_BASE_URL is optional

--- a/src/dbt_jobs_as_code/importer/__init__.py
+++ b/src/dbt_jobs_as_code/importer/__init__.py
@@ -1,4 +1,4 @@
-from beartype.typing import List, Optional, TextIO
+from beartype.typing import List, Optional
 from loguru import logger
 
 from dbt_jobs_as_code.client import DBTCloud
@@ -6,12 +6,12 @@ from dbt_jobs_as_code.loader.load import load_job_configuration
 from dbt_jobs_as_code.schemas.job import JobDefinition
 
 
-def get_account_id(config_file: Optional[TextIO], account_id: Optional[int]) -> int:
+def get_account_id(config_files: Optional[List[str]], account_id: Optional[int]) -> int:
     """Get account ID from either config file or direct input"""
     if account_id:
         return account_id
-    elif config_file:
-        defined_jobs = load_job_configuration(config_file, None).jobs.values()
+    elif config_files:
+        defined_jobs = load_job_configuration(config_files, None).jobs.values()
         return list(defined_jobs)[0].account_id
     else:
         raise ValueError("Either config or account_id must be provided")

--- a/src/dbt_jobs_as_code/loader/load.py
+++ b/src/dbt_jobs_as_code/loader/load.py
@@ -1,5 +1,7 @@
+import glob
+
 import yaml
-from beartype.typing import Optional, Set, TextIO
+from beartype.typing import List, Optional, Set
 from jinja2 import Environment, StrictUndefined, meta
 from jinja2.exceptions import UndefinedError
 from loguru import logger
@@ -11,15 +13,15 @@ class LoadingJobsYAMLError(Exception):
     pass
 
 
-def load_job_configuration(config_file: TextIO, vars_file: Optional[TextIO]) -> Config:
+def load_job_configuration(config_files: List[str], vars_file: Optional[List[str]]) -> Config:
     """Load the job configuration set in a YAML file into a Config object
 
     Can be a non-templated YAML or a templated one for which we need to replace Jinja values
     """
     if vars_file:
-        config = _load_yaml_with_template(config_file, vars_file)
+        config = _load_yaml_with_template(config_files, vars_file)
     else:
-        config = _load_yaml_no_template(config_file)
+        config = _load_yaml_no_template(config_files)
 
     if not config["jobs"]:
         return Config(jobs={})
@@ -42,34 +44,80 @@ def load_job_configuration(config_file: TextIO, vars_file: Optional[TextIO]) -> 
     return Config(**config)
 
 
-def _load_yaml_no_template(config_file: TextIO) -> dict:
+def _load_yaml_no_template(config_files: List[str]) -> dict:
     """Load a job YAML file into a Config object"""
-    config_string = config_file.read()
 
-    jinja_vars = _get_jinja_variables(config_string)
-    if jinja_vars:
-        raise LoadingJobsYAMLError(
-            f"This is a templated YAML file. Please remove the variables {jinja_vars} or provide the variables values."
-        )
+    combined_config = {}
+    for config_file in config_files:
+        with open(config_file) as f:
+            config_string = f.read()
 
-    return yaml.safe_load(config_string)
+            jinja_vars = _get_jinja_variables(config_string)
+            if jinja_vars:
+                raise LoadingJobsYAMLError(
+                    f"{config_file} is a templated YAML file. Please remove the variables {jinja_vars} or provide the variables values."
+                )
+
+            config = yaml.safe_load(config_string)
+            if config:
+                # Merge the jobs from each file into combined_config
+                if "jobs" in config:
+                    if "jobs" not in combined_config:
+                        combined_config["jobs"] = {}
+                    combined_config["jobs"].update(config["jobs"])
+                # Merge any other top-level keys
+                for key, value in config.items():
+                    if key != "jobs":
+                        combined_config[key] = value
+
+    return combined_config
 
 
-def _load_yaml_with_template(config_file: TextIO, vars_file: TextIO) -> dict:
+def _load_yaml_with_template(config_files: List[str], vars_file: List[str]) -> dict:
     """Load a job YAML file into a Config object"""
-    template_vars_values = yaml.safe_load(vars_file)
-    config_string_unrendered = config_file.read()
+    # Load and merge vars files
+    template_vars_values = {}
+    for vars_path in vars_file:
+        with open(vars_path) as f:
+            # we load the vars. if there is no data in them we set it to an empty dict
+            vars_data = yaml.safe_load(f) or {}
+            # Check for duplicate variables
+            for key in vars_data:
+                if key in template_vars_values:
+                    raise LoadingJobsYAMLError(
+                        f"Variable '{key}' is defined multiple times in vars files"
+                    )
+            template_vars_values.update(vars_data)
 
+    # Load and combine config files
+    combined_config = {}
     env = Environment(undefined=StrictUndefined)
-    template = env.from_string(config_string_unrendered)
 
-    try:
-        config_string_rendered = template.render(template_vars_values)
-    except UndefinedError as e:
-        print(f"Error: {e}")  # This will raise an error
-        raise LoadingJobsYAMLError(f"Some variables didn't have a value: {e.message}.") from e
+    for config_path in config_files:
+        with open(config_path) as f:
+            config_string_unrendered = f.read()
+            template = env.from_string(config_string_unrendered)
 
-    return yaml.safe_load(config_string_rendered)
+            try:
+                config_string_rendered = template.render(template_vars_values)
+            except UndefinedError as e:
+                raise LoadingJobsYAMLError(
+                    f"Some variables didn't have a value: {e.message}."
+                ) from e
+
+            config = yaml.safe_load(config_string_rendered)
+            if config:
+                # Merge the jobs from each file
+                if "jobs" in config:
+                    if "jobs" not in combined_config:
+                        combined_config["jobs"] = {}
+                    combined_config["jobs"].update(config["jobs"])
+                # Merge any other top-level keys
+                for key, value in config.items():
+                    if key != "jobs":
+                        combined_config[key] = value
+
+    return combined_config
 
 
 def _get_jinja_variables(input: str) -> Set[str]:
@@ -77,3 +125,35 @@ def _get_jinja_variables(input: str) -> Set[str]:
     env = Environment()
     parsed_input = env.parse(input)
     return meta.find_undeclared_variables(parsed_input)
+
+
+def resolve_file_paths(
+    config_pattern: Optional[str], vars_pattern: Optional[str] = None
+) -> tuple[List[str], List[str]]:
+    """
+    Resolve glob patterns to lists of file paths.
+
+    Args:
+        config_pattern: Glob pattern for config files
+        vars_pattern: Optional glob pattern for vars files
+
+    Returns:
+        Tuple of (config_files, vars_files)
+
+    Raises:
+        LoadingJobsYAMLError: If no files match a pattern when pattern is provided
+    """
+    if not config_pattern:
+        return [], []
+
+    config_files = glob.glob(config_pattern)
+    if not config_files:
+        raise LoadingJobsYAMLError(f"No files found matching pattern: {config_pattern}")
+
+    vars_files = []
+    if vars_pattern:
+        vars_files = glob.glob(vars_pattern)
+        if not vars_files:
+            raise LoadingJobsYAMLError(f"No files found matching pattern: {vars_pattern}")
+
+    return config_files, vars_files

--- a/src/dbt_jobs_as_code/schemas/common_types.py
+++ b/src/dbt_jobs_as_code/schemas/common_types.py
@@ -1,6 +1,6 @@
 from beartype.typing import Any, Dict, List, Literal, Optional
 from croniter import croniter
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 
 def set_one_of_string_integer(schema: Dict[str, Any]):

--- a/src/dbt_jobs_as_code/schemas/job.py
+++ b/src/dbt_jobs_as_code/schemas/job.py
@@ -1,6 +1,6 @@
 import re
 
-from beartype.typing import Any, Dict, List, Optional
+from beartype.typing import Any, List, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 from dbt_jobs_as_code.schemas.common_types import (

--- a/tests/cloud_yaml_mapping/test_validate_link.py
+++ b/tests/cloud_yaml_mapping/test_validate_link.py
@@ -1,10 +1,10 @@
 import copy
-from typing import Optional
 from unittest.mock import Mock
 
 import pytest
+
 from dbt_jobs_as_code.client import DBTCloud, DBTCloudException
-from dbt_jobs_as_code.cloud_yaml_mapping.validate_link import LinkableCheck, can_be_linked
+from dbt_jobs_as_code.cloud_yaml_mapping.validate_link import can_be_linked
 from dbt_jobs_as_code.schemas.job import JobDefinition
 
 

--- a/tests/integration-tests/test_flow.py
+++ b/tests/integration-tests/test_flow.py
@@ -1,13 +1,13 @@
 import io
 import os
-import sys
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+from loguru import logger
+
 from dbt_jobs_as_code.client import DBTCloud
 from dbt_jobs_as_code.main import cli
-from loguru import logger
 
 ACCOUNT_ID = int(os.getenv("DBT_ACCOUNT_ID", 0))
 PROJECT_ID = int(os.getenv("DBT_PROJECT_ID", 0))

--- a/tests/loader/conftest.py
+++ b/tests/loader/conftest.py
@@ -1,0 +1,165 @@
+import pytest
+
+
+@pytest.fixture
+def single_config_content():
+    return """
+jobs:
+  job1:
+    project_id: {{ project_id }}
+    environment_id: {{ env_id }}
+"""
+
+
+@pytest.fixture
+def single_vars_content():
+    return """
+project_id: 123
+env_id: 456
+"""
+
+
+@pytest.fixture
+def config_files(tmp_path, single_config_content):
+    config_file = tmp_path / "config.yml"
+    config_file.write_text(single_config_content)
+    return [str(config_file)]
+
+
+@pytest.fixture
+def vars_files(tmp_path, single_vars_content):
+    vars_file = tmp_path / "vars.yml"
+    vars_file.write_text(single_vars_content)
+    return [str(vars_file)]
+
+
+@pytest.fixture
+def multiple_config_files(tmp_path):
+    config1 = tmp_path / "config1.yml"
+    config2 = tmp_path / "config2.yml"
+
+    config1.write_text("""
+jobs:
+  job1:
+    project_id: {{ project_id }}
+""")
+
+    config2.write_text("""
+jobs:
+  job2:
+    environment_id: {{ env_id }}
+""")
+
+    return [str(config1), str(config2)]
+
+
+@pytest.fixture
+def multiple_vars_files(tmp_path):
+    vars1 = tmp_path / "vars1.yml"
+    vars2 = tmp_path / "vars2.yml"
+
+    vars1.write_text("project_id: 123")
+    vars2.write_text("env_id: 456")
+
+    return [str(vars1), str(vars2)]
+
+
+@pytest.fixture
+def expected_config_dict():
+    return {
+        "jobs": {
+            "job1": {
+                "account_id": 43791,
+                "compare_changes_flags": "--select state:modified",
+                "custom_environment_variables": [],
+                "dbt_version": None,
+                "deferring_environment_id": None,
+                "deferring_job_definition_id": None,
+                "description": "",
+                "environment_id": 134459,
+                "execute_steps": [
+                    "dbt run --select model1+",
+                    "dbt run --select model2+",
+                    "dbt compile",
+                ],
+                "execution": {"timeout_seconds": 0},
+                "generate_docs": False,
+                "id": None,
+                "identifier": "job1",
+                "job_completion_trigger_condition": None,
+                "job_type": "scheduled",
+                "linked_id": None,
+                "name": "My Job 1 with a new name",
+                "project_id": 176941,
+                "run_generate_sources": True,
+                "schedule": {
+                    "cron": "0 */2 * * *",
+                    "date": {"cron": "0 */2 * * *", "type": "custom_cron"},
+                    "time": {"interval": 1, "type": "every_hour"},
+                },
+                "settings": {"target_name": "production", "threads": 4},
+                "state": 1,
+                "triggers": {
+                    "git_provider_webhook": False,
+                    "github_webhook": False,
+                    "on_merge": False,
+                    "schedule": True,
+                },
+                "triggers_on_draft_pr": False,
+                "run_compare_changes": False,
+            },
+            "job2": {
+                "account_id": 43791,
+                "compare_changes_flags": "--select state:modified",
+                "custom_environment_variables": [
+                    {
+                        "display_value": None,
+                        "job_definition_id": None,
+                        "name": "DBT_ENV1",
+                        "type": "job",
+                        "value": "My val",
+                    },
+                    {
+                        "display_value": None,
+                        "job_definition_id": None,
+                        "name": "DBT_ENV2",
+                        "type": "job",
+                        "value": "My val2",
+                    },
+                ],
+                "dbt_version": None,
+                "deferring_environment_id": None,
+                "deferring_job_definition_id": None,
+                "description": "",
+                "environment_id": 134459,
+                "execute_steps": ["dbt run-operation clone_all_production_schemas", "dbt compile"],
+                "execution": {"timeout_seconds": 0},
+                "generate_docs": True,
+                "id": None,
+                "identifier": "job2",
+                "job_completion_trigger_condition": {
+                    "condition": {"job_id": 123, "project_id": 234, "statuses": [10, 20]}
+                },
+                "job_type": "other",
+                "linked_id": None,
+                "name": "CI/CD run",
+                "project_id": 176941,
+                "run_generate_sources": True,
+                "schedule": {
+                    "cron": "0 * * * *",
+                    "date": {"cron": "0 * * * *", "type": "custom_cron"},
+                    "time": {"interval": 1, "type": "every_hour"},
+                },
+                "settings": {"target_name": "TEST", "threads": 4},
+                "state": 1,
+                "triggers": {
+                    "git_provider_webhook": False,
+                    "github_webhook": True,
+                    "on_merge": True,
+                    "schedule": False,
+                },
+                "triggers_on_draft_pr": True,
+                "run_compare_changes": True,
+            },
+        }
+    }

--- a/tests/schemas/test_custom_environment_variables.py
+++ b/tests/schemas/test_custom_environment_variables.py
@@ -3,7 +3,6 @@ from pydantic import ValidationError
 
 from dbt_jobs_as_code.schemas.custom_environment_variable import (
     CustomEnvironmentVariable,
-    CustomEnvironmentVariablePayload,
 )
 
 


### PR DESCRIPTION
Fixes #122 

The following options are now possible: 
- `dbt-jobs-as-code plan .dbt/jobs/*`
- `dbt-jobs-as-code plan .dbt/jobs/*.yml`
- `dbt-jobs-as-code plan .dbt/jobs/prod*.yml`
- `dbt-jobs-as-code plan .dbt/jobs/**/*.yml`

etc... [Any glob following Unix matching](https://docs.python.org/3/library/glob.html)  should work