### PR TITLE
Link jobs to existing ID when importing jobs

### DIFF
--- a/src/dbt_jobs_as_code/exporter/export.py
+++ b/src/dbt_jobs_as_code/exporter/export.py
@@ -10,7 +10,8 @@ def export_jobs_yml(jobs: list[JobDefinition], include_linked_id: bool = False):
 
     export_yml = {"jobs": {}}
     for id, cloud_job in enumerate(jobs):
-        export_yml["jobs"][f"import_{id + 1}"] = cloud_job.to_load_format(include_linked_id)
+        yaml_key = cloud_job.identifier if cloud_job.identifier else f"import_{id + 1}"
+        export_yml["jobs"][yaml_key] = cloud_job.to_load_format(include_linked_id)
 
     print(
         "# yaml-language-server: $schema=https://raw.githubusercontent.com/dbt-labs/dbt-jobs-as-code/main/src/dbt_jobs_as_code/schemas/load_job_schema.json"

--- a/src/dbt_jobs_as_code/loader/load.py
+++ b/src/dbt_jobs_as_code/loader/load.py
@@ -23,7 +23,7 @@ def load_job_configuration(config_files: List[str], vars_file: Optional[List[str
     else:
         config = _load_yaml_no_template(config_files)
 
-    if not config["jobs"]:
+    if config.get("jobs", {}) == {}:
         return Config(jobs={})
 
     date_config = [job.get("schedule", {}).get("date", None) for job in config["jobs"].values()]
@@ -61,7 +61,7 @@ def _load_yaml_no_template(config_files: List[str]) -> dict:
             config = yaml.safe_load(config_string)
             if config:
                 # Merge the jobs from each file into combined_config
-                if "jobs" in config:
+                if config.get("jobs", {}) != {}:
                     if "jobs" not in combined_config:
                         combined_config["jobs"] = {}
                     combined_config["jobs"].update(config["jobs"])


### PR DESCRIPTION
Closes #121 (or I believe so 🤣)

Now, when using import-jobs on a job that is already managed via dbt-jobs-as-code (i.e. contains an identifier in `[[ ... ]]`), the identifier in the outputted YAML will be the existing one, meaning that a plan/sync would result in no change rather than deleting one job and creating a new one.