### PR TITLE
Add `--json` parameter to `plan` and `sync`

### DIFF
--- a/docs/advanced_config/jobs_importing.md
+++ b/docs/advanced_config/jobs_importing.md
@@ -73,7 +73,7 @@ dbt-jobs-as-code import-jobs --account-id 1234 --project-id 3213 --environment-i
 It would then be possible to automate the creation of PRs whenever the `jobs.yml` file is updated, meaning that some jobs would have been updated in the dbt Cloud UI. The GitHub action [Create Pull Request](https://github.com/marketplace/actions/create-pull-request) could be used to implement this flow.
 
 
-Then, the `jobs.yml` file can be used to import the jobs in a different environment with the following command, like described in [YAML templating](templating.md) and in the [typical flows](../typical_flows.md) page :
+Then, the `jobs.yml` file can be used to import the jobs in a different environment with the following command, like described in [YAML templating](templating.md) and in the [typical flows](../typical_flows.md#advanced-flows) page :
 
 ```bash
 dbt-jobs-as-code plan jobs.yml -v qa_vars.yml --limit-projects-envs-to-yml

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,10 @@
 
 To see the details of all changes, head to the GitHub repo
 
+### 1.5
+
+- Add `--json` to `plan` and `sync` to output the `stdout` changes in JSON format. This can be useful for automating some processes and consuming the changes from scripts. We are still printing logs to `stderr` though, so to remove those logs you can redirect `stderr` to `/dev/null` or redirect `stdout` to a file and then read from the file.
+
 ### 1.4
 
 - Add `--templated-fields` to `import-jobs` to add Jinja variables to the generated YAML file. This can be useful to allow users to maintain jobs in the dbt Cloud UI and set a process to automatically promote those to other environments.

--- a/src/dbt_jobs_as_code/loader/load.py
+++ b/src/dbt_jobs_as_code/loader/load.py
@@ -73,6 +73,14 @@ def _load_yaml_no_template(config_files: List[str]) -> dict:
     return combined_config
 
 
+def _replace_none_with_null(obj):
+    if isinstance(obj, dict):
+        return {k: _replace_none_with_null(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_replace_none_with_null(item) for item in obj]
+    return "null" if obj is None else obj
+
+
 def _load_vars_files(vars_file: List[str]) -> dict:
     """Load and merge multiple vars files into a single dictionary.
 
@@ -97,7 +105,7 @@ def _load_vars_files(vars_file: List[str]) -> dict:
                         f"Variable '{key}' is defined multiple times in vars files"
                     )
             template_vars_values.update(vars_data)
-    return template_vars_values
+    return _replace_none_with_null(template_vars_values)  # type: ignore
 
 
 def _load_yaml_with_template(config_files: List[str], vars_file: List[str]) -> dict:

--- a/src/dbt_jobs_as_code/schemas/__init__.py
+++ b/src/dbt_jobs_as_code/schemas/__init__.py
@@ -1,9 +1,5 @@
-import json
-
-from beartype.typing import Any, Optional, Tuple
+from beartype.typing import Any, Dict, Optional, Tuple
 from deepdiff import DeepDiff
-from loguru import logger
-from rich.console import Console
 
 from dbt_jobs_as_code.schemas.custom_environment_variable import (
     CustomEnvironmentVariable,
@@ -31,38 +27,43 @@ def _job_to_dict(job: JobDefinition):
     return dict_vals
 
 
-def check_job_mapping_same(source_job: JobDefinition, dest_job: JobDefinition) -> bool:
-    """Checks if the source and destination jobs are the same"""
+def check_job_mapping_same(
+    source_job: JobDefinition, dest_job: JobDefinition
+) -> Tuple[bool, Optional[Dict]]:
+    """Checks if the source and destination jobs are the same
 
+    Returns:
+        Tuple[bool, Optional[Dict]]: A tuple containing:
+            - bool: True if jobs are identical, False otherwise
+            - Optional[Dict]: None if jobs are identical, otherwise a dict containing the differences
+    """
     source_job_dict = _job_to_dict(source_job)
     dest_job_dict = _job_to_dict(dest_job)
 
     diffs = _get_mismatched_dict_entries(dest_job_dict, source_job_dict)
 
     if len(diffs) == 0:
-        logger.success(f"✅ Job {source_job.identifier} is identical")
-        return True
+        return True, None
     else:
-        # we can't json.dump types normally, so we provide a custom logic to just return the type name
-        def type_serializer(obj):
-            if isinstance(obj, type):
-                return obj.__name__
-            raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
-
-        # TODO: Move printing to the main file
-        console = Console()
-        console.log(
-            f"❌ Job {source_job.identifier} is different - Diff:\n{json.dumps(diffs, indent=2, default=type_serializer)}"
-        )
-        return False
+        return False, {
+            "job_id": source_job.identifier,
+            "status": "different",
+            "differences": diffs,
+        }
 
 
 def check_env_var_same(
     source_env_var: CustomEnvironmentVariable,
     dest_env_vars: dict[str, CustomEnvironmentVariablePayload],
-) -> Tuple[bool, Optional[int]]:
-    """Checks if the source env vars is the same in the destination env vars"""
+) -> Tuple[bool, Optional[int], Optional[Dict]]:
+    """Checks if the source env vars is the same in the destination env vars
 
+    Returns:
+        Tuple[bool, Optional[int], Optional[Dict]]: A tuple containing:
+            - bool: True if env vars are identical, False otherwise
+            - Optional[int]: The env var ID if it exists
+            - Optional[Dict]: None if env vars are identical, otherwise a dict containing the differences
+    """
     if source_env_var.name not in dest_env_vars:
         raise Exception(
             f"Custom environment variable {source_env_var.name} not found in dbt Cloud, "
@@ -72,12 +73,13 @@ def check_env_var_same(
     env_var_id = dest_env_vars[source_env_var.name].id
 
     if dest_env_vars[source_env_var.name].value == source_env_var.value:
-        logger.debug(
-            f"The env var {source_env_var.name} is already up to date for the job {source_env_var.job_definition_id}."
-        )
-        return (True, env_var_id)
+        return True, env_var_id, None
     else:
-        # TODO: Move printing to the main file
-        console = Console()
-        console.log(f"❌ The env var overwrite for {source_env_var.name} is different")
-        return (False, env_var_id)
+        return (
+            False,
+            env_var_id,
+            {
+                "old_value": dest_env_vars[source_env_var.name].value,
+                "new_value": source_env_var.value,
+            },
+        )

--- a/tests/changeset/test_change_set.py
+++ b/tests/changeset/test_change_set.py
@@ -1,0 +1,209 @@
+from unittest.mock import Mock
+
+from dbt_jobs_as_code.cloud_yaml_mapping.change_set import Change, ChangeSet
+
+
+def test_change_set_to_json_empty():
+    """Test that an empty change set produces correct JSON structure"""
+    change_set = ChangeSet()
+    json_output = change_set.to_json()
+
+    assert json_output == {
+        "job_changes": [],
+        "env_var_overwrite_changes": [],
+    }
+
+
+def test_change_set_to_json_job_changes():
+    """Test that job changes are correctly represented in JSON"""
+    change_set = ChangeSet()
+
+    # Add a CREATE job change
+    change_set.append(
+        Change(
+            identifier="job1",
+            type="job",
+            action="create",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+        )
+    )
+
+    # Add an UPDATE job change with differences
+    change_set.append(
+        Change(
+            identifier="job2",
+            type="job",
+            action="update",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+            differences={
+                "values_changed": {
+                    "root['name']": {"new_value": "new_name", "old_value": "old_name"}
+                }
+            },
+        )
+    )
+
+    # Add a DELETE job change
+    change_set.append(
+        Change(
+            identifier="job3",
+            type="job",
+            action="delete",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+        )
+    )
+
+    json_output = change_set.to_json()
+
+    assert len(json_output["job_changes"]) == 3
+    assert len(json_output["env_var_overwrite_changes"]) == 0
+
+    # Verify CREATE job
+    create_job = next(c for c in json_output["job_changes"] if c["action"] == "CREATE")
+    assert create_job["identifier"] == "job1"
+    assert create_job["project_id"] == 123
+    assert create_job["environment_id"] == 456
+
+    # Verify UPDATE job with differences
+    update_job = next(c for c in json_output["job_changes"] if c["action"] == "UPDATE")
+    assert update_job["identifier"] == "job2"
+    assert "differences" in update_job
+    assert update_job["differences"]["values_changed"]["root['name']"]["new_value"] == "new_name"
+
+    # Verify DELETE job
+    delete_job = next(c for c in json_output["job_changes"] if c["action"] == "DELETE")
+    assert delete_job["identifier"] == "job3"
+
+
+def test_change_set_to_json_env_var_changes():
+    """Test that environment variable changes are correctly represented in JSON"""
+    change_set = ChangeSet()
+
+    # Add a CREATE env var change
+    change_set.append(
+        Change(
+            identifier="job1:DBT_VAR1",
+            type="env var overwrite",
+            action="create",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+        )
+    )
+
+    # Add an UPDATE env var change with differences
+    change_set.append(
+        Change(
+            identifier="job1:DBT_VAR2",
+            type="env var overwrite",
+            action="update",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+            differences={"old_value": "old_val", "new_value": "new_val"},
+        )
+    )
+
+    # Add a DELETE env var change
+    change_set.append(
+        Change(
+            identifier="job1:DBT_VAR3",
+            type="env var overwrite",
+            action="delete",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+        )
+    )
+
+    json_output = change_set.to_json()
+
+    assert len(json_output["job_changes"]) == 0
+    assert len(json_output["env_var_overwrite_changes"]) == 3
+
+    # Verify CREATE env var
+    create_var = next(
+        c for c in json_output["env_var_overwrite_changes"] if c["action"] == "CREATE"
+    )
+    assert create_var["identifier"] == "job1:DBT_VAR1"
+    assert create_var["project_id"] == 123
+    assert create_var["environment_id"] == 456
+
+    # Verify UPDATE env var with differences
+    update_var = next(
+        c for c in json_output["env_var_overwrite_changes"] if c["action"] == "UPDATE"
+    )
+    assert update_var["identifier"] == "job1:DBT_VAR2"
+    assert "differences" in update_var
+    assert update_var["differences"]["old_value"] == "old_val"
+    assert update_var["differences"]["new_value"] == "new_val"
+
+    # Verify DELETE env var
+    delete_var = next(
+        c for c in json_output["env_var_overwrite_changes"] if c["action"] == "DELETE"
+    )
+    assert delete_var["identifier"] == "job1:DBT_VAR3"
+
+
+def test_change_set_to_json_mixed_changes():
+    """Test that a mix of job and env var changes are correctly represented in JSON"""
+    change_set = ChangeSet()
+
+    # Add a job change
+    change_set.append(
+        Change(
+            identifier="job1",
+            type="job",
+            action="update",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+            differences={
+                "values_changed": {
+                    "root['name']": {"new_value": "new_name", "old_value": "old_name"}
+                }
+            },
+        )
+    )
+
+    # Add an env var change
+    change_set.append(
+        Change(
+            identifier="job1:DBT_VAR1",
+            type="env var overwrite",
+            action="update",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+            differences={"old_value": "old_val", "new_value": "new_val"},
+        )
+    )
+
+    json_output = change_set.to_json()
+
+    assert len(json_output["job_changes"]) == 1
+    assert len(json_output["env_var_overwrite_changes"]) == 1
+
+    # Verify job change
+    job_change = json_output["job_changes"][0]
+    assert job_change["identifier"] == "job1"
+    assert "differences" in job_change
+
+    # Verify env var change
+    env_var_change = json_output["env_var_overwrite_changes"][0]
+    assert env_var_change["identifier"] == "job1:DBT_VAR1"
+    assert "differences" in env_var_change

--- a/tests/loader/test_loader.py
+++ b/tests/loader/test_loader.py
@@ -315,3 +315,33 @@ schedule:
         result = _load_vars_files([str(vars_file)])
 
         assert result == {"schedule": {"cron": "0 1,5 * * 0,1,2,3,4,5"}}
+
+    def test_load_vars_files_none_values(self, tmp_path):
+        """Test that None values in vars files are correctly replaced with 'null' strings"""
+        vars_file = tmp_path / "vars.yml"
+        vars_file.write_text("""
+string_var: value
+none_var: null
+nested_dict:
+    none_field: null
+list_with_none:
+    - item1
+    - null
+    - item3
+nested_list:
+    - name: item1
+      value: null
+    - name: item2
+      value: not_null
+        """)
+
+        result = _load_vars_files([str(vars_file)])
+
+        assert result["string_var"] == "value"
+        assert result["none_var"] == "null"
+        assert result["nested_dict"]["none_field"] == "null"
+        assert result["list_with_none"] == ["item1", "null", "item3"]
+        assert result["nested_list"] == [
+            {"name": "item1", "value": "null"},
+            {"name": "item2", "value": "not_null"},
+        ]

--- a/tests/schemas/test_check_job_mapping_same.py
+++ b/tests/schemas/test_check_job_mapping_same.py
@@ -31,4 +31,8 @@ def test_check_job_mapping_same():
         triggers={},
     )
 
-    assert not check_job_mapping_same(mock_job1, mock_job2)
+    # Test that the jobs are different
+    same, diff = check_job_mapping_same(mock_job1, mock_job2)
+    assert not same
+    assert diff is not None
+    assert diff["status"] == "different"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,15 @@
-from unittest.mock import patch
+import json
+from unittest.mock import Mock, patch
 
 import pytest
 from click.testing import CliRunner
 
-from dbt_jobs_as_code.main import import_jobs
+from dbt_jobs_as_code.cloud_yaml_mapping.change_set import Change, ChangeSet
+from dbt_jobs_as_code.main import cli, import_jobs
 from dbt_jobs_as_code.schemas.common_types import Settings, Triggers
 from dbt_jobs_as_code.schemas.job import JobDefinition
+
+# ============= Fixtures =============
 
 
 @pytest.fixture
@@ -55,6 +59,55 @@ def mock_dbt_cloud():
         yield instance
 
 
+@pytest.fixture
+def mock_change_set():
+    """Create a mock change set with both job and env var changes"""
+    change_set = ChangeSet()
+
+    # Add a job change
+    change_set.append(
+        Change(
+            identifier="job1",
+            type="job",
+            action="update",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+            differences={
+                "values_changed": {
+                    "root['name']": {"new_value": "new_name", "old_value": "old_name"}
+                }
+            },
+        )
+    )
+
+    # Add an env var change
+    change_set.append(
+        Change(
+            identifier="job1:DBT_VAR1",
+            type="env var overwrite",
+            action="update",
+            proj_id=123,
+            env_id=456,
+            sync_function=Mock(),
+            parameters={},
+            differences={"old_value": "old_val", "new_value": "new_val"},
+        )
+    )
+
+    return change_set
+
+
+@pytest.fixture
+def mock_empty_change_set():
+    """Create an empty change set"""
+    return ChangeSet()
+
+
+# ============= Import Command Tests =============
+
+
 def test_import_jobs_managed_only(mock_dbt_cloud):
     """Test that --managed-only flag only imports jobs with identifiers"""
     runner = CliRunner()
@@ -98,3 +151,143 @@ def test_import_jobs_without_managed_only(mock_dbt_cloud):
     assert "managed-job-1" in result.stdout
     assert "managed-job-2" in result.stdout
     assert "Unmanaged Job" in result.stdout
+
+
+# ============= Plan Command Tests =============
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_plan_command_json_output(mock_build_change_set, mock_change_set):
+    """Test that plan command produces valid JSON output when --json flag is used"""
+    mock_build_change_set.return_value = mock_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["plan", "--json", "config.yml"])
+
+    assert result.exit_code == 0
+
+    # Verify the output is valid JSON
+    json_output = json.loads(result.output)
+
+    # Verify structure
+    assert "job_changes" in json_output
+    assert "env_var_overwrite_changes" in json_output
+
+    # Verify job changes
+    assert len(json_output["job_changes"]) == 1
+    job_change = json_output["job_changes"][0]
+    assert job_change["identifier"] == "job1"
+    assert job_change["action"] == "UPDATE"
+    assert "differences" in job_change
+
+    # Verify env var changes
+    assert len(json_output["env_var_overwrite_changes"]) == 1
+    env_var_change = json_output["env_var_overwrite_changes"][0]
+    assert env_var_change["identifier"] == "job1:DBT_VAR1"
+    assert env_var_change["action"] == "UPDATE"
+    assert "differences" in env_var_change
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_plan_command_json_output_no_changes(mock_build_change_set, mock_empty_change_set):
+    """Test that plan command produces valid JSON output with no changes"""
+    mock_build_change_set.return_value = mock_empty_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["plan", "--json", "config.yml"])
+
+    assert result.exit_code == 0
+
+    # Verify the output is valid JSON
+    json_output = json.loads(result.output)
+
+    # Verify structure
+    assert json_output == {
+        "job_changes": [],
+        "env_var_overwrite_changes": [],
+    }
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_plan_command_regular_output(mock_build_change_set, mock_change_set):
+    """Test that plan command produces regular output when --json flag is not used"""
+    mock_build_change_set.return_value = mock_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["plan", "config.yml"])
+
+    assert result.exit_code == 0
+
+    # Verify this is not JSON
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.output)
+
+
+# ============= Sync Command Tests =============
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_sync_command_json_output(mock_build_change_set, mock_change_set):
+    """Test that sync command produces valid JSON output when --json flag is used"""
+    mock_build_change_set.return_value = mock_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["sync", "--json", "config.yml"])
+
+    assert result.exit_code == 0
+
+    # Verify the output is valid JSON
+    json_output = json.loads(result.output)
+
+    # Verify structure
+    assert "job_changes" in json_output
+    assert "env_var_overwrite_changes" in json_output
+
+    # Verify job changes
+    assert len(json_output["job_changes"]) == 1
+    job_change = json_output["job_changes"][0]
+    assert job_change["identifier"] == "job1"
+    assert job_change["action"] == "UPDATE"
+    assert "differences" in job_change
+
+    # Verify env var changes
+    assert len(json_output["env_var_overwrite_changes"]) == 1
+    env_var_change = json_output["env_var_overwrite_changes"][0]
+    assert env_var_change["identifier"] == "job1:DBT_VAR1"
+    assert env_var_change["action"] == "UPDATE"
+    assert "differences" in env_var_change
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_sync_command_json_output_no_changes(mock_build_change_set, mock_empty_change_set):
+    """Test that sync command produces valid JSON output with no changes"""
+    mock_build_change_set.return_value = mock_empty_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["sync", "--json", "config.yml"])
+
+    assert result.exit_code == 0
+
+    # Verify the output is valid JSON
+    json_output = json.loads(result.output)
+
+    # Verify structure
+    assert json_output == {
+        "job_changes": [],
+        "env_var_overwrite_changes": [],
+    }
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_sync_command_regular_output(mock_build_change_set, mock_change_set):
+    """Test that sync command produces regular output when --json flag is not used"""
+    mock_build_change_set.return_value = mock_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["sync", "config.yml"])
+
+    assert result.exit_code == 0
+
+    # Verify this is not JSON
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.output)


### PR DESCRIPTION
Add `--json` parameter to `plan` and `sync` to improve experience when using automation in CI/CD processes

With this parameter `stdout` gets formatted as a single JSON object.