### PR TITLE
Change the max size of YAML export

### DIFF
--- a/src/dbt_jobs_as_code/exporter/export.py
+++ b/src/dbt_jobs_as_code/exporter/export.py
@@ -68,7 +68,7 @@ def export_jobs_yml(
     )
     print("")
 
-    yaml.width = 300
+    yaml.width = 4096
     yaml.block_seq_indent = 2
     # Convert back to standard template syntax before output
     stream = StringIO()


### PR DESCRIPTION
In case of a very large step, the YAML export of the job gets moved to a new line and the YAML is not valid anymore