### PR TITLE
feat: support config as dir path only

### DIFF
--- a/src/dbt_jobs_as_code/cloud_yaml_mapping/change_set.py
+++ b/src/dbt_jobs_as_code/cloud_yaml_mapping/change_set.py
@@ -188,6 +188,8 @@ def build_change_set(
     CONFIG is the path to your jobs.yml config file.
     """
     # Get list of files matching the glob pattern
+    if os.path.isdir(config):
+        config = os.path.join(config, "**/*.yml")
     config_files = glob.glob(config)
     if not config_files:
         logger.error(f"No files found matching pattern: {config}")


### PR DESCRIPTION
This is to support to pass the CONFIG as a Directory Path instead of glob pattern, in particular to support Windows users who use CMD and to deal with the glob pattern with `*` character since CMD dislikes this character.

Sample command that failed with Error when trying to Plan/Sync 2+ yml files:

```sh
# Error: Got extra arguments (xxx/file2.yml)
dbt-jobs-as-code plan path/to/jobs/*.yml
dbt-jobs-as-code "plan path/to/jobs/*.yml"

# No error but no files detected in the path `path/to/jobs/^*.yml `
dbt-jobs-as-code plan path/to/jobs/^*.yml # ^ is to escape * in CMD
```

**Expected result:**

These commands are equivalent:

```
dbt-jobs-as-code plan path/to/jobs/*.yml
dbt-jobs-as-code plan path/to/jobs
```