### PR TITLE
Add ability to exclude specific job identifiers patterns in plan/sync

### DIFF
--- a/src/dbt_jobs_as_code/main.py
+++ b/src/dbt_jobs_as_code/main.py
@@ -67,6 +67,12 @@ option_json_output = click.option(
     help="Output results in JSON format instead of human-readable text.",
 )
 
+option_exclude_identifiers_matching = click.option(
+    "--exclude-identifiers-matching",
+    type=str,
+    help="Exclude jobs from dbt Cloud if their identifiers match this regex pattern.",
+)
+
 
 @click.group(
     help=f"dbt-jobs-as-code {VERSION}\n\nA CLI to allow defining dbt Cloud jobs as code",
@@ -85,6 +91,7 @@ def cli() -> None:
 @option_environment_ids
 @option_limit_projects_envs_to_yml
 @option_json_output
+@option_exclude_identifiers_matching
 @click.option(
     "--fail-fast",
     is_flag=True,
@@ -98,6 +105,7 @@ def sync(
     limit_projects_envs_to_yml,
     disable_ssl_verification,
     output_json: bool,
+    exclude_identifiers_matching: str,
     fail_fast: bool,
 ):
     """Synchronize a dbt Cloud job config file against dbt Cloud.
@@ -128,6 +136,7 @@ def sync(
         cloud_project_ids,
         cloud_environment_ids,
         limit_projects_envs_to_yml,
+        exclude_identifiers_matching,
         output_json=output_json,
     )
     if len(change_set) == 0:
@@ -157,6 +166,7 @@ def sync(
 @option_environment_ids
 @option_limit_projects_envs_to_yml
 @option_json_output
+@option_exclude_identifiers_matching
 def plan(
     config: str,
     vars_yml: str,
@@ -165,6 +175,7 @@ def plan(
     limit_projects_envs_to_yml: bool,
     disable_ssl_verification: bool,
     output_json: bool,
+    exclude_identifiers_matching: str,
 ):
     """Check the difference between a local file and dbt Cloud without updating dbt Cloud.
     This command will not update dbt Cloud.
@@ -193,6 +204,7 @@ def plan(
         cloud_project_ids,
         cloud_environment_ids,
         limit_projects_envs_to_yml,
+        exclude_identifiers_matching,
         output_json=output_json,
     )
     if len(change_set) == 0:

--- a/tests/cloud_yaml_mapping/test_exclude_identifiers.py
+++ b/tests/cloud_yaml_mapping/test_exclude_identifiers.py
@@ -1,0 +1,346 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from dbt_jobs_as_code.cloud_yaml_mapping.change_set import ChangeSet, build_change_set
+from dbt_jobs_as_code.schemas.common_types import Settings, Triggers
+from dbt_jobs_as_code.schemas.job import JobDefinition
+
+
+@pytest.fixture
+def sample_jobs():
+    """Create sample jobs for testing"""
+    base_job = JobDefinition(
+        project_id=123,
+        environment_id=456,
+        account_id=789,
+        name="Base Job",
+        settings=Settings(threads=4),
+        run_generate_sources=False,
+        execute_steps=["dbt run"],
+        generate_docs=False,
+        schedule={"cron": "0 * * * *"},
+        triggers=Triggers(schedule=True),
+    )
+
+    return [
+        base_job.model_copy(
+            update={
+                "id": 1,
+                "name": "Production Job",
+                "identifier": "prod:daily-run",
+            }
+        ),
+        base_job.model_copy(
+            update={
+                "id": 2,
+                "name": "Staging Job",
+                "identifier": "staging:nightly-test",
+            }
+        ),
+        base_job.model_copy(
+            update={
+                "id": 3,
+                "name": "Development Job",
+                "identifier": "dev:feature-test",
+            }
+        ),
+        base_job.model_copy(
+            update={
+                "id": 4,
+                "name": "Legacy Job",
+                "identifier": "legacy:old-process",
+            }
+        ),
+        base_job.model_copy(
+            update={
+                "id": 5,
+                "name": "Temp Job",
+                "identifier": "temp:experimental",
+            }
+        ),
+        base_job.model_copy(
+            update={
+                "id": 6,
+                "name": "Unmanaged Job",
+                "identifier": None,
+            }
+        ),
+    ]
+
+
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.load_job_configuration")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.DBTCloud")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.glob.glob")
+def test_exclude_identifiers_matching_no_pattern(
+    mock_glob, mock_dbt_cloud_class, mock_load_config, sample_jobs
+):
+    """Test that when no exclude pattern is provided, all jobs are processed"""
+    # Create a sample job definition for the mock config
+    sample_job = sample_jobs[0]
+
+    # Mock the configuration loading with a non-empty jobs dictionary
+    mock_config = Mock()
+    mock_config.jobs = {"test-job": sample_job}  # Non-empty to avoid early return
+    mock_load_config.return_value = mock_config
+    mock_glob.return_value = ["test.yml"]
+
+    # Mock the DBT Cloud client
+    mock_dbt_cloud = Mock()
+    mock_dbt_cloud_class.return_value = mock_dbt_cloud
+    mock_dbt_cloud.get_jobs.return_value = sample_jobs
+    mock_dbt_cloud.build_mapping_job_identifier_job_id.return_value = {}
+
+    # Call build_change_set without exclude pattern
+    result = build_change_set(
+        config="test.yml",
+        yml_vars=None,
+        disable_ssl_verification=False,
+        project_ids=[],
+        environment_ids=[],
+        exclude_identifiers_matching=None,
+    )
+
+    # Verify that get_jobs was called (jobs should be processed normally)
+    mock_dbt_cloud.get_jobs.assert_called_once()
+    # The function should complete successfully
+    assert isinstance(result, ChangeSet)
+
+
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.load_job_configuration")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.DBTCloud")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.glob.glob")
+def test_exclude_identifiers_matching_simple_pattern(
+    mock_glob, mock_dbt_cloud_class, mock_load_config, sample_jobs
+):
+    """Test that jobs matching a simple regex pattern are excluded"""
+    # Create a sample job definition for the mock config
+    sample_job = sample_jobs[0]
+
+    # Mock the configuration loading
+    mock_config = Mock()
+    mock_config.jobs = {"test-job": sample_job}
+    mock_load_config.return_value = mock_config
+    mock_glob.return_value = ["test.yml"]
+
+    # Mock the DBT Cloud client
+    mock_dbt_cloud = Mock()
+    mock_dbt_cloud_class.return_value = mock_dbt_cloud
+    mock_dbt_cloud.get_jobs.return_value = sample_jobs
+    mock_dbt_cloud.build_mapping_job_identifier_job_id.return_value = {}
+
+    # Call build_change_set with exclude pattern for staging jobs
+    result = build_change_set(
+        config="test.yml",
+        yml_vars=None,
+        disable_ssl_verification=False,
+        project_ids=[],
+        environment_ids=[],
+        exclude_identifiers_matching="staging:.*",
+    )
+
+    # Verify the result is a valid ChangeSet
+    assert isinstance(result, ChangeSet)
+    # The staging job should have been filtered out before processing
+
+
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.load_job_configuration")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.DBTCloud")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.glob.glob")
+def test_exclude_identifiers_matching_multiple_patterns(
+    mock_glob, mock_dbt_cloud_class, mock_load_config, sample_jobs
+):
+    """Test that jobs matching multiple patterns are excluded"""
+    # Mock the configuration loading
+    mock_config = Mock()
+    mock_config.jobs = {"test-job": sample_jobs[0]}
+    mock_load_config.return_value = mock_config
+    mock_glob.return_value = ["test.yml"]
+
+    # Mock the DBT Cloud client
+    mock_dbt_cloud = Mock()
+    mock_dbt_cloud_class.return_value = mock_dbt_cloud
+    mock_dbt_cloud.get_jobs.return_value = sample_jobs
+    mock_dbt_cloud.build_mapping_job_identifier_job_id.return_value = {}
+
+    # Call build_change_set with pattern matching legacy and temp jobs
+    result = build_change_set(
+        config="test.yml",
+        yml_vars=None,
+        disable_ssl_verification=False,
+        project_ids=[],
+        environment_ids=[],
+        exclude_identifiers_matching="(legacy|temp):.*",
+    )
+
+    # Verify the result is a valid ChangeSet
+    assert isinstance(result, ChangeSet)
+
+
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.load_job_configuration")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.DBTCloud")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.glob.glob")
+def test_exclude_identifiers_matching_jobs_without_identifier(
+    mock_glob, mock_dbt_cloud_class, mock_load_config, sample_jobs
+):
+    """Test that jobs without identifiers are not affected by exclude pattern"""
+    # Mock the configuration loading
+    mock_config = Mock()
+    mock_config.jobs = {"test-job": sample_jobs[0]}
+    mock_load_config.return_value = mock_config
+    mock_glob.return_value = ["test.yml"]
+
+    # Mock the DBT Cloud client
+    mock_dbt_cloud = Mock()
+    mock_dbt_cloud_class.return_value = mock_dbt_cloud
+    mock_dbt_cloud.get_jobs.return_value = sample_jobs
+    mock_dbt_cloud.build_mapping_job_identifier_job_id.return_value = {}
+
+    # Call build_change_set with pattern that would match if identifier existed
+    result = build_change_set(
+        config="test.yml",
+        yml_vars=None,
+        disable_ssl_verification=False,
+        project_ids=[],
+        environment_ids=[],
+        exclude_identifiers_matching=".*",  # This would match anything if identifier exists
+    )
+
+    # Verify the result is a valid ChangeSet
+    assert isinstance(result, ChangeSet)
+    # Jobs without identifiers should not be excluded
+
+
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.load_job_configuration")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.DBTCloud")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.glob.glob")
+def test_exclude_identifiers_matching_invalid_regex(
+    mock_glob, mock_dbt_cloud_class, mock_load_config, sample_jobs
+):
+    """Test that invalid regex patterns are handled gracefully"""
+    # Mock the configuration loading
+    mock_config = Mock()
+    mock_config.jobs = {"test-job": sample_jobs[0]}
+    mock_load_config.return_value = mock_config
+    mock_glob.return_value = ["test.yml"]
+
+    # Mock the DBT Cloud client
+    mock_dbt_cloud = Mock()
+    mock_dbt_cloud_class.return_value = mock_dbt_cloud
+    mock_dbt_cloud.get_jobs.return_value = sample_jobs
+    mock_dbt_cloud.build_mapping_job_identifier_job_id.return_value = {}
+
+    # Call build_change_set with invalid regex pattern
+    result = build_change_set(
+        config="test.yml",
+        yml_vars=None,
+        disable_ssl_verification=False,
+        project_ids=[],
+        environment_ids=[],
+        exclude_identifiers_matching="[invalid-regex",  # Missing closing bracket
+    )
+
+    # Should return empty ChangeSet when regex is invalid
+    assert isinstance(result, ChangeSet)
+    assert len(result) == 0
+
+
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.load_job_configuration")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.DBTCloud")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.glob.glob")
+def test_exclude_identifiers_matching_case_sensitive(
+    mock_glob, mock_dbt_cloud_class, mock_load_config, sample_jobs
+):
+    """Test that regex matching is case sensitive"""
+    # Mock the configuration loading
+    mock_config = Mock()
+    mock_config.jobs = {"test-job": sample_jobs[0]}
+    mock_load_config.return_value = mock_config
+    mock_glob.return_value = ["test.yml"]
+
+    # Mock the DBT Cloud client
+    mock_dbt_cloud = Mock()
+    mock_dbt_cloud_class.return_value = mock_dbt_cloud
+    mock_dbt_cloud.get_jobs.return_value = sample_jobs
+    mock_dbt_cloud.build_mapping_job_identifier_job_id.return_value = {}
+
+    # Call build_change_set with uppercase pattern (should not match lowercase identifiers)
+    result = build_change_set(
+        config="test.yml",
+        yml_vars=None,
+        disable_ssl_verification=False,
+        project_ids=[],
+        environment_ids=[],
+        exclude_identifiers_matching="STAGING:.*",  # Uppercase, won't match "staging:.*"
+    )
+
+    # Verify the result is a valid ChangeSet (no jobs should be excluded)
+    assert isinstance(result, ChangeSet)
+
+
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.load_job_configuration")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.DBTCloud")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.glob.glob")
+def test_exclude_identifiers_matching_partial_match(
+    mock_glob, mock_dbt_cloud_class, mock_load_config, sample_jobs
+):
+    """Test that partial matches work correctly"""
+    # Mock the configuration loading
+    mock_config = Mock()
+    mock_config.jobs = {"test-job": sample_jobs[0]}
+    mock_load_config.return_value = mock_config
+    mock_glob.return_value = ["test.yml"]
+
+    # Mock the DBT Cloud client
+    mock_dbt_cloud = Mock()
+    mock_dbt_cloud_class.return_value = mock_dbt_cloud
+    mock_dbt_cloud.get_jobs.return_value = sample_jobs
+    mock_dbt_cloud.build_mapping_job_identifier_job_id.return_value = {}
+
+    # Call build_change_set with pattern that matches part of identifier
+    result = build_change_set(
+        config="test.yml",
+        yml_vars=None,
+        disable_ssl_verification=False,
+        project_ids=[],
+        environment_ids=[],
+        exclude_identifiers_matching="test",  # Should match both "nightly-test" and "feature-test"
+    )
+
+    # Verify the result is a valid ChangeSet
+    assert isinstance(result, ChangeSet)
+
+
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.load_job_configuration")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.DBTCloud")
+@patch("dbt_jobs_as_code.cloud_yaml_mapping.change_set.glob.glob")
+def test_exclude_identifiers_matching_with_json_output(
+    mock_glob, mock_dbt_cloud_class, mock_load_config, sample_jobs
+):
+    """Test that JSON output mode works correctly with exclude pattern"""
+    # Mock the configuration loading
+    mock_config = Mock()
+    mock_config.jobs = {"test-job": sample_jobs[0]}
+    mock_load_config.return_value = mock_config
+    mock_glob.return_value = ["test.yml"]
+
+    # Mock the DBT Cloud client
+    mock_dbt_cloud = Mock()
+    mock_dbt_cloud_class.return_value = mock_dbt_cloud
+    mock_dbt_cloud.get_jobs.return_value = sample_jobs
+    mock_dbt_cloud.build_mapping_job_identifier_job_id.return_value = {}
+
+    # Call build_change_set with JSON output enabled
+    result = build_change_set(
+        config="test.yml",
+        yml_vars=None,
+        disable_ssl_verification=False,
+        project_ids=[],
+        environment_ids=[],
+        exclude_identifiers_matching="staging:.*",
+        output_json=True,
+    )
+
+    # Verify the result is a valid ChangeSet
+    assert isinstance(result, ChangeSet)
+    # JSON output should not affect the filtering behavior

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -323,3 +323,139 @@ def test_sync_command_without_fail_fast(mock_build_change_set):
 
     # Verify that apply was called with fail_fast=False (default)
     mock_change_set.apply.assert_called_once_with(fail_fast=False)
+
+
+# ============= Exclude Identifiers Matching Tests =============
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_plan_command_with_exclude_identifiers_matching(
+    mock_build_change_set, mock_empty_change_set
+):
+    """Test that plan command passes exclude_identifiers_matching parameter correctly"""
+    mock_build_change_set.return_value = mock_empty_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "config.yml", "--exclude-identifiers-matching", "staging:.*"]
+    )
+
+    assert result.exit_code == 0
+
+    # Verify that build_change_set was called with the correct exclude_identifiers_matching parameter
+    mock_build_change_set.assert_called_once()
+    call_args = mock_build_change_set.call_args
+
+    # Check positional arguments
+    assert call_args[0][0] == "config.yml"  # config
+    assert call_args[0][1] is None  # vars_yml
+    assert call_args[0][2] is False  # disable_ssl_verification
+    assert call_args[0][3] == []  # project_ids
+    assert call_args[0][4] == []  # environment_ids
+    assert call_args[0][5] is False  # limit_projects_envs_to_yml
+    assert call_args[0][6] == "staging:.*"  # exclude_identifiers_matching
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_sync_command_with_exclude_identifiers_matching(
+    mock_build_change_set, mock_empty_change_set
+):
+    """Test that sync command passes exclude_identifiers_matching parameter correctly"""
+    mock_build_change_set.return_value = mock_empty_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["sync", "config.yml", "--exclude-identifiers-matching", "legacy:.*"]
+    )
+
+    assert result.exit_code == 0
+
+    # Verify that build_change_set was called with the correct exclude_identifiers_matching parameter
+    mock_build_change_set.assert_called_once()
+    call_args = mock_build_change_set.call_args
+
+    # Check that exclude_identifiers_matching parameter is passed correctly
+    assert call_args[0][6] == "legacy:.*"  # exclude_identifiers_matching
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_plan_command_without_exclude_identifiers_matching(
+    mock_build_change_set, mock_empty_change_set
+):
+    """Test that plan command works when exclude_identifiers_matching is not provided"""
+    mock_build_change_set.return_value = mock_empty_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["plan", "config.yml"])
+
+    assert result.exit_code == 0
+
+    # Verify that build_change_set was called with None for exclude_identifiers_matching
+    mock_build_change_set.assert_called_once()
+    call_args = mock_build_change_set.call_args
+
+    # Check that exclude_identifiers_matching parameter is None
+    assert call_args[0][6] is None  # exclude_identifiers_matching
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_sync_command_without_exclude_identifiers_matching(
+    mock_build_change_set, mock_empty_change_set
+):
+    """Test that sync command works when exclude_identifiers_matching is not provided"""
+    mock_build_change_set.return_value = mock_empty_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["sync", "config.yml"])
+
+    assert result.exit_code == 0
+
+    # Verify that build_change_set was called with None for exclude_identifiers_matching
+    mock_build_change_set.assert_called_once()
+    call_args = mock_build_change_set.call_args
+
+    # Check that exclude_identifiers_matching parameter is None
+    assert call_args[0][6] is None  # exclude_identifiers_matching
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_plan_command_with_complex_regex_pattern(mock_build_change_set, mock_empty_change_set):
+    """Test that plan command handles complex regex patterns correctly"""
+    mock_build_change_set.return_value = mock_empty_change_set
+
+    runner = CliRunner()
+    complex_pattern = "(staging|temp|legacy):.*test.*"
+    result = runner.invoke(
+        cli, ["plan", "config.yml", "--exclude-identifiers-matching", complex_pattern]
+    )
+
+    assert result.exit_code == 0
+
+    # Verify that build_change_set was called with the correct complex pattern
+    mock_build_change_set.assert_called_once()
+    call_args = mock_build_change_set.call_args
+
+    # Check that the complex pattern is passed correctly
+    assert call_args[0][6] == complex_pattern  # exclude_identifiers_matching
+
+
+@patch("dbt_jobs_as_code.main.build_change_set")
+def test_sync_command_with_json_and_exclude_pattern(mock_build_change_set, mock_empty_change_set):
+    """Test that sync command works with both --json and --exclude-identifiers-matching flags"""
+    mock_build_change_set.return_value = mock_empty_change_set
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["sync", "config.yml", "--json", "--exclude-identifiers-matching", "temp:.*"]
+    )
+
+    assert result.exit_code == 0
+
+    # Verify that build_change_set was called with both parameters
+    mock_build_change_set.assert_called_once()
+    call_args = mock_build_change_set.call_args
+
+    # Check that exclude_identifiers_matching parameter is passed
+    assert call_args[0][6] == "temp:.*"  # exclude_identifiers_matching
+    # Check that output_json is True
+    assert call_args.kwargs.get("output_json") is True


### PR DESCRIPTION
Closes #166

The flag `--exclude-identifiers-matching` has been added for `plan` and `sync` and can be used to exclude specific identifiers.

The use case could be that:
- different pipelines create jobs in one given dbt environment (e.g. some common jobs and some project specific ones)
- without this feature, each time one pipeline is run, the jobs created from the other pipeline would be deleted
- with this feature, each pipeline could create jobs with specific identifiers and exclude the jobs from the other pipeline during plan/sync to avoid removing them
  - e.g., the common pipeline could create jobs with identifiers like `com-abc`, `com-def`... and run plan/sync with `--exclude-identifiers-matching "^proj-*"`
  - e.g., and the project pipeline could create jobs with identifiers like `proj-xyz`... and run plan/sync with `--exclude-identifiers-matching "^com-*"`