### PR TITLE
fix: support directory paths in CLI commands

### DIFF
--- a/docs/advanced_config/glob_config_files.md
+++ b/docs/advanced_config/glob_config_files.md
@@ -14,4 +14,8 @@ dbt-jobs-as-code plan "jobs/**/*.yml" # (1)!
 
 1. Depending on your shell you might have to quote the pattern or not. For example, for `zsh` quoting is required as otherwise the shell will try to expand the pattern before passing it to the command.
 
-If the provided config is a directory, we automatically search for all the `*.yml` files in this directory. This is particularly relevant for users with a shell not supporting the `*` character.
+If the provided config is a directory, we automatically search for all the `*.yml` and `*.yaml` files in this directory. This is particularly relevant for users with a shell not supporting the `*` character.
+
+```bash
+dbt-jobs-as-code plan ./jobs  # Equivalent to ./jobs/*.yml + ./jobs/*.yaml
+```


### PR DESCRIPTION
## Summary

- When users pass a directory path to commands like `validate`, `plan`, or `sync`, the CLI now automatically finds all `.yml` and `.yaml` files in that directory
- Previously this would crash with `IsADirectoryError`

Example usage:
```bash
dbt-jobs-as-code validate ./jobs  # Now works!
```

## Changes

- Added `_resolve_pattern()` helper in `loader/load.py` that detects directories and expands them to `*.yml` + `*.yaml`
- Added 7 new tests for directory handling
- Updated documentation to mention both `.yml` and `.yaml` support

Fixes #180