### PR TITLE
add completed_operations logging output with IDs of synced jobs

### DIFF
--- a/src/dbt_jobs_as_code/client/__init__.py
+++ b/src/dbt_jobs_as_code/client/__init__.py
@@ -354,7 +354,7 @@ class DBTCloud:
         logger.success(f"Updated the env_var {custom_env_var.name} for job {job_id}")
         return CustomEnvironmentVariablePayload(**(response.json()["data"]))
 
-    def delete_env_var(self, project_id: int, env_var_id: int) -> None:
+    def delete_env_var(self, project_id: int, env_var_id: int, job_id: Optional[int] = None) -> None:
         """Delete env_var job overwrite in dbt Cloud."""
 
         logger.debug(f"Deleting env var id {env_var_id}")

--- a/src/dbt_jobs_as_code/main.py
+++ b/src/dbt_jobs_as_code/main.py
@@ -153,6 +153,10 @@ def sync(
             console.log(change_set.to_table())
     change_set.apply(fail_fast=fail_fast)
 
+    # Output completed operations with job IDs (only for JSON output)
+    if output_json and len(change_set) > 0:
+        print(json.dumps(change_set.to_completed_operations_json()))
+
     if not change_set.apply_success:
         logger.error("-- SYNC -- There were some errors during the sync. Check the logs.")
         sys.exit(1)


### PR DESCRIPTION
## Summary

Closes #182 

Adds job ID logging to the `sync` command's JSON output, enabling users to programmatically trigger jobs immediately after they are created or updated via the CLI.

When running `dbt-jobs-as-code sync jobs.yml --json`, the command now outputs two JSON objects:
1. **Before sync**: Planned changes (existing behavior)
2. **After sync**: Completed operations with job IDs (new)

This enables workflows like:

```
dbt-jobs-as-code sync jobs.yml --json | tail -1 | \
jq -r '.completed_operations[].job_id' | sort -u | \
xargs -I {} dbtc trigger-job --account-id 1 --job-id {}
```


### Changes Made

- Added `result_job_id` field to `Change` class to capture job IDs after operations complete
- Updated `Change.apply()` to extract job IDs from:
  - Job operations: CREATE/UPDATE return `JobDefinition.id`, DELETE uses ID from parameters
  - Env var operations: CREATE/UPDATE return `CustomEnvironmentVariablePayload.job_definition_id`, DELETE uses ID from parameters
- Added `ChangeSet.to_completed_operations_json()` method to return structured JSON with completed operations and their job IDs
- Updated `sync` command in `main.py` to output completed operations JSON after `apply()` when `--json` flag is used
- Updated `delete_env_var()` signature to accept optional `job_id` parameter for consistency

### Example Output

```
# it'll be inline like other json output
{
  "completed_operations": [
    {
      "action": "CREATE",
      "type": "Job",
      "identifier": "daily_refresh",
      "job_id": 12345,
      "project_id": 100,
      "environment_id": 200
    },
    {
      "action": "UPDATE",
      "type": "Env Var Overwrite",
      "identifier": "daily_refresh:DBT_TARGET",
      "job_id": 12345,
      "project_id": 100,
      "environment_id": 200
    }
  ]
}
```

## Checklist

Please ensure the following before submitting your PR:

- [x] Tests pass locally (`uv run pytest`)
- [x] Code follows project style guidelines (`ruff` linting passes)
- [x] New functionality includes appropriate tests
- [ ] Documentation has been updated if needed
- [ ] **If this PR changes YAML fields**: Run `uv run dbt-jobs-as-code update-json-schema` and commit the updated JSON schema

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Added 5 new tests covering:

- Job ID capture on create operations
- Completed operations JSON generation (empty and with operations)
- Integration with sync command
- Edge cases (empty changesets)