### PR TITLE
fix: enable recursive glob patterns with **

### DIFF
--- a/src/dbt_jobs_as_code/cloud_yaml_mapping/change_set.py
+++ b/src/dbt_jobs_as_code/cloud_yaml_mapping/change_set.py
@@ -197,12 +197,12 @@ def build_change_set(
     if os.path.isdir(config):
         config = os.path.join(config, "*.yml")
     # Get list of files matching the glob pattern
-    config_files = glob.glob(config)
+    config_files = glob.glob(config, recursive=True)
     if not config_files:
         logger.error(f"No files found matching pattern: {config}")
         return ChangeSet()
 
-    yml_vars_files = glob.glob(yml_vars) if yml_vars else None
+    yml_vars_files = glob.glob(yml_vars, recursive=True) if yml_vars else None
 
     try:
         configuration = load_job_configuration(config_files, yml_vars_files)

--- a/src/dbt_jobs_as_code/loader/load.py
+++ b/src/dbt_jobs_as_code/loader/load.py
@@ -197,7 +197,7 @@ def _resolve_pattern(pattern: str) -> List[str]:
         yaml_files = glob.glob(os.path.join(pattern, "*.yaml"))
         return yml_files + yaml_files
     else:
-        return glob.glob(pattern)
+        return glob.glob(pattern, recursive=True)
 
 
 def resolve_file_paths(

--- a/tests/loader/test_loader.py
+++ b/tests/loader/test_loader.py
@@ -456,6 +456,22 @@ class TestLoaderResolveFilePaths:
         assert config_files == [str(config_file)]
         assert len(vars_files) == 2
 
+    def test_resolve_file_paths_recursive_glob(self, tmp_path):
+        """Test resolving files with recursive ** glob pattern (issue #185)"""
+        jobs_dir = tmp_path / "jobs"
+        # Create nested directory structure
+        (jobs_dir / "category1" / "subcategory1").mkdir(parents=True)
+        (jobs_dir / "category2").mkdir(parents=True)
+
+        (jobs_dir / "top_level.yml").write_text("content")
+        (jobs_dir / "category1" / "job1.yml").write_text("content1")
+        (jobs_dir / "category1" / "subcategory1" / "job2.yml").write_text("content2")
+        (jobs_dir / "category2" / "job3.yml").write_text("content3")
+
+        config_files, vars_files = resolve_file_paths(str(jobs_dir / "**" / "*.yml"))
+        assert len(config_files) == 4
+        assert all(f.endswith(".yml") for f in config_files)
+
     def test_resolve_file_paths_with_vars(self, tmp_path):
         """Test resolving both config and vars files"""
         config_file = tmp_path / "config.yml"


### PR DESCRIPTION
## Summary
- Passes `recursive=True` to all `glob.glob()` calls so that `**` patterns correctly match zero or more directories
- Fixes `./jobs/**/*.yml` only matching one level deep instead of recursively

Closes #185

## Test plan
- [x] Added `test_resolve_file_paths_recursive_glob` test with nested directory structure (`jobs/category1/subcategory1/job.yml`)
- [x] All 123 existing tests pass
- [x] Pre-commit hooks (ruff, ruff-format) pass