### PR TITLE
fix: trigger CI when ci-ok label is added to fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
       - '**'
+    types: [opened, synchronize, reopened, labeled]
   schedule:
     - cron: '0 2 * * 0'
 


### PR DESCRIPTION
## Summary
- Adds the `labeled` activity type to the `pull_request_target` trigger in the CI workflow

Previously, adding the `ci-ok` label to a fork PR required closing and reopening the PR to generate a fresh event payload. This change lets the workflow fire directly when a maintainer adds the label.

## Test plan
- Add `ci-ok` label to a fork PR and verify CI triggers without needing to close/reopen