### PR TITLE
docs: update changelog version to 1.14

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,7 @@
 
 To see the details of all changes, head to the GitHub repo
 
-### 1.7
+### 1.14
 
 - Add applied job IDs to `sync --json` output. The JSON now includes an `applied` section with `job_id` for each operation and an `apply_success` flag. See [JSON output](advanced_config/json_output.md) for details.
 


### PR DESCRIPTION
## Summary
- Updates the changelog entry for the JSON output feature to use version 1.14

Follows up on #183 which was merged with version 1.7 in the changelog.

## Test plan
- Verify changelog renders correctly in mkdocs