### PR TITLE
fix: add deactivation_reason to JobMissingFields

### DIFF
--- a/src/dbt_jobs_as_code/schemas/job.py
+++ b/src/dbt_jobs_as_code/schemas/job.py
@@ -304,6 +304,7 @@ class JobMissingFields(JobDefinition):
 
     # Unneeded read-only fields
     raw_dbt_version: Optional[str] = None
+    deactivation_reason: Optional[Any] = None
     created_at: str = ""
     updated_at: str = ""
     deactivated: bool


### PR DESCRIPTION
## Summary

- dbt Cloud API now returns a `deactivation_reason` field (value: `None`) in job responses
- `JobMissingFields` uses `extra="forbid"`, causing the weekly scheduled test to fail with a `ValidationError`
- Added `deactivation_reason: Optional[Any] = None` to the "Unneeded read-only fields" section of `JobMissingFields`

## Test plan

- [ ] Weekly scheduled CI test (`tests/schemas/test_missing_fields.py::test_new_job_fields`) should pass
- [ ] All 210 unit tests pass locally