### PR TITLE
fix: handle null parent nodes in apply_templated_fields

### DIFF
--- a/src/dbt_jobs_as_code/exporter/export.py
+++ b/src/dbt_jobs_as_code/exporter/export.py
@@ -22,7 +22,7 @@ def apply_templated_fields(
     def set_nested_value(d: Dict[Any, Any], path: str, value: str):
         parts = path.split(".")
         for part in parts[:-1]:
-            if part not in d:
+            if part not in d or d[part] is None:
                 d[part] = {}
             d = d[part]
         d[parts[-1]] = value

--- a/tests/exporter/test_export.py
+++ b/tests/exporter/test_export.py
@@ -214,6 +214,20 @@ def test_apply_templated_fields_missing_path():
     assert result["name"] == "test job"  # Unchanged field
 
 
+def test_apply_templated_fields_null_parent():
+    """Test applying templated fields when a parent node is null (e.g. job_completion_trigger_condition is null)"""
+    job_dict = {"name": "test job", "job_completion_trigger_condition": None}
+
+    template_config = {"job_completion_trigger_condition.condition.project_id": "{{ project_id }}"}
+
+    result = apply_templated_fields(job_dict, template_config)
+
+    assert (
+        result["job_completion_trigger_condition"]["condition"]["project_id"] == "{{ project_id }}"
+    )
+    assert result["name"] == "test job"
+
+
 def test_apply_templated_fields_empty_config():
     """Test applying empty template config"""
     job_dict = {"name": "test job", "environment_id": 123}


### PR DESCRIPTION
## Summary

- `apply_templated_fields` crashed with `TypeError: argument of type 'NoneType' is not iterable` when a job had `job_completion_trigger_condition: null` and `--templated-fields` included a dotted path into that field (e.g. `job_completion_trigger_condition.condition.project_id`)
- Fixed by treating a null parent node the same as a missing key — replacing it with an empty dict before navigating further
- Added a regression test covering this case

## Context

Triggered when users template nested fields in the job completion trigger condition across multi-environment migrations, where some jobs have `job_completion_trigger_condition: null` and others do not.

## Test plan

- [ ] `uv run pytest tests/exporter/test_export.py` — all 10 tests pass
- [ ] Run `import-jobs --templated-fields` with a template that includes `job_completion_trigger_condition.condition.project_id` against an account that has a mix of jobs with and without a job completion trigger condition