### PR TITLE
Remove unreachable code and fix wrong type default

### DIFF
--- a/src/dbt_jobs_as_code/client/__init__.py
+++ b/src/dbt_jobs_as_code/client/__init__.py
@@ -149,7 +149,6 @@ class DBTCloud:
         if response.status_code >= 400:
             logger.error(response.json())
             raise DBTCloudException(f"Error creating job {job.name}")
-            return None
         else:
             logger.success("Job created successfully.")
 

--- a/src/dbt_jobs_as_code/schemas/job.py
+++ b/src/dbt_jobs_as_code/schemas/job.py
@@ -308,7 +308,7 @@ class JobMissingFields(JobDefinition):
     created_at: str = ""
     updated_at: str = ""
     deactivated: bool
-    run_failure_count: int = False
+    run_failure_count: int = 0
     lifecycle_webhooks: bool = False
     lifecycle_webhooks_url: Optional[str] = None
     is_deferrable: bool = False


### PR DESCRIPTION
## Summary

- **`client/__init__.py` line 152**: Removed unreachable `return None` statement after a `raise DBTCloudException(...)`. The `return` could never execute.
- **`schemas/job.py` line 311**: Changed `run_failure_count: int = False` to `run_failure_count: int = 0`. The field is typed as `int` so its default should be `0`, not `False`.

## Test plan

- Both changes are semantically neutral (dead code removal and correcting a default that was already falsy), so no behavioral change is expected.
- Existing tests should continue to pass.